### PR TITLE
Invert icons based on theme

### DIFF
--- a/Doll/Source/AppSettings.swift
+++ b/Doll/Source/AppSettings.swift
@@ -28,4 +28,16 @@ class AppSettings {
     static func isGiantBadgeEnabled(for appName: String) -> Bool {
         AppSettings.giantBadgeConfigs[appName] ?? false
     }
+
+    @UserDefaultSetting("SETTINGS_APPS_ICON_MASK")
+    static var iconMasksConfigs: [String: Bool] = [:]
+
+    static func toggleIconMask(for appName: String, value: Bool) {
+        AppSettings.iconMasksConfigs[appName] = value
+    }
+
+    static func isIconMask(for appName: String) -> Bool {
+        AppSettings.iconMasksConfigs[appName] ?? false
+    }
+
 }

--- a/Doll/Utils/NSImageExtensions.swift
+++ b/Doll/Utils/NSImageExtensions.swift
@@ -67,6 +67,32 @@ extension NSImage {
         grayImage.addRepresentation(grayscale)
         return grayImage
     }
+
+    func invert() -> NSImage? {
+        guard let cgImage = cgImage(forProposedRect: nil, context: nil, hints: nil) else {
+            return nil
+        }
+
+        let ciImage = CIImage(cgImage: cgImage)
+
+        guard let filter = CIFilter(name: "CIColorInvert") else {
+            print("Could not create CIColorInvert filter")
+            return nil
+        }
+
+        filter.setValue(ciImage, forKey: kCIInputImageKey)
+        guard let outputImage = filter.outputImage else {
+            print("Could not obtain output CIImage from filter")
+            return nil
+        }
+
+        let context = CIContext(options: nil)
+        guard let cgOutImage = context.createCGImage(outputImage, from: outputImage.extent) else {
+            return nil
+        }
+
+        return NSImage(cgImage: cgOutImage, size: size)
+    }
 }
 
 extension NSBitmapImageRep {

--- a/Doll/Views/MonitorConfigView.swift
+++ b/Doll/Views/MonitorConfigView.swift
@@ -20,6 +20,7 @@ struct MonitorConfigView: View {
     @State var selectedApp: MonitoredApp?
     @State var selectedAppItem: AppItem?
     @State var showGiantBadge: Bool = false
+    @State var iconIsMask: Bool = false
     @State var keyword: String = ""
     @State private var defaultFocusSet = false
     @State private var allAppItems: [AppItem] = []
@@ -80,7 +81,34 @@ struct MonitorConfigView: View {
                         pickApplication()
                     }
                 }
-                        .padding()
+                .padding()
+
+                HStack {
+                    if !isAddMode, let selectedApp = selectedApp {
+
+                        Toggle("Use the icon as a mask", isOn: $iconIsMask)
+                            .onChange(of: iconIsMask) { enabled in
+                                AppSettings.toggleIconMask(for: selectedApp.appName, value: enabled)
+                                 MonitorEngine.shared.statusBars.forEach {
+                                    $0.refreshIcon()
+                                }
+                            }
+                            .onAppear {
+                                iconIsMask = AppSettings.isIconMask(for: selectedApp.appName)
+                            }
+
+                        Toggle("Show a red arrow", isOn: $showGiantBadge)
+                            .onChange(of: showGiantBadge) { enabled in
+                                AppSettings.toggleGiantBadge(for: selectedApp.appName, value: enabled)
+                            }
+                            .onAppear {
+                                showGiantBadge = AppSettings.isGiantBadgeEnabled(for: selectedApp.appName)
+                            }
+
+                        Spacer()
+                    }
+                }
+                .padding()
 
                 ApplicationListView(activeItem: selectedAppBinding, allApps: filteredAppItems)
                         .onAppear {
@@ -107,13 +135,6 @@ struct MonitorConfigView: View {
                 HStack {
 
                     if !isAddMode, let selectedApp = selectedApp {
-                        Toggle("Show a red arrow so you don't miss any notifications! :)", isOn: $showGiantBadge)
-                            .onChange(of: showGiantBadge) { enabled in
-                                AppSettings.toggleGiantBadge(for: selectedApp.appName, value: enabled)
-                            }
-                            .onAppear {
-                                showGiantBadge = AppSettings.isGiantBadgeEnabled(for: selectedApp.appName)
-                            }
 
                         Spacer()
 

--- a/Doll/Views/StatusBarController.swift
+++ b/Doll/Views/StatusBarController.swift
@@ -7,6 +7,7 @@ let defaultIcon = #imageLiteral(resourceName: "DefaultStatusBarIcon")
 
 class StatusBarController {
     private var statusBar: NSStatusBar!
+    private var isDark = false
     private var latestBadgeText = ""
     private var latestMessageCount = 0
 
@@ -49,6 +50,11 @@ class StatusBarController {
 
     func refreshIcon() {
         monitoredAppIcon = Storage.appIcon(for: monitoredApp?.bundleId ?? "")
+
+        if(AppSettings.isIconMask(for: monitoredApp?.appName ?? "") && isDark) {
+            monitoredAppIcon = monitoredAppIcon?.invert()
+        }
+
         updateBadgeText(latestBadgeText, force: true)
     }
 
@@ -110,6 +116,12 @@ class StatusBarController {
             if appIsNotRunningAndIconShouldBeHidden || badgeIsEmptyAndIconShouldBeHidden {
                 self?.hideStatusBar()
             } else {
+                let currentIsDark = self?.statusItem.button?.effectiveAppearance.name.rawValue.lowercased().contains("dark") ?? false
+                if(self?.isDark != currentIsDark) {
+                    self?.isDark = currentIsDark
+                    self?.refreshIcon()
+                }
+
                 self?.updateBadgeText(badge)
             }
 


### PR DESCRIPTION
This MR changes the look of the icons based on the current theme/appearance of the notification bar. The approach taken expects a black-transparent image (mask) and will then invert it to white based on the theme. This feature can be toggled through a new checkbox within the badge setting.  

Key Changes

* Dynamic Icon Adaptation: Icons now adjust to the notification bar's theme.
* User Control: Added a new checkbox in the app settings, allowing users to toggle this feature based on their preference.

Issues

The theme is taken from the current active screen, which leads to a mismatched color on some screens if the user has multiple different wallpapers. I don't know how to solve this.

Resolves

* #27