### PR TITLE
Fixed the problem of 2-digit notifications got truncated

### DIFF
--- a/Doll/Views/StatusBarController.swift
+++ b/Doll/Views/StatusBarController.swift
@@ -161,10 +161,6 @@ class StatusBarController {
             return
         }
 
-        let textWidth = (text ?? "")
-            .width(withConstrainedHeight: defaultIconSize, font: .systemFont(ofSize: 14))
-        statusItem.length = defaultIconSize + textWidth
-
         // New notification comes in
         let newText = text ?? ""
 
@@ -185,10 +181,23 @@ class StatusBarController {
         } else {
             let defaultIcon = monitoredAppIcon
             let adjustedIcon = (newText.isEmpty && AppSettings.grayoutIconWhenNothingComing) ? (defaultIcon.grayOut() ?? defaultIcon) : defaultIcon
-            updateBadgeIcon(icon: adjustedIcon)
-            statusItem.length = defaultIconSize + textWidth
             updateBadgeIcon(icon: adjustedIcon, size: CGSize(width: defaultIconSize, height: defaultIconSize))
+
+            // Set title first
             statusItem.button?.title = newText
+
+            // Calculate text width
+            let textWidth = (newText)
+                .width(withConstrainedHeight: defaultIconSize, font: .systemFont(ofSize: 14))
+
+            // Account for NSStatusBarButton's internal spacing between image and title (typically 4-6pt)
+            // macOS 15.2 enforces this spacing more strictly
+            let interElementSpacing: CGFloat = 4
+            statusItem.length = defaultIconSize + interElementSpacing + textWidth
+
+            // Force layout update
+            statusItem.button?.needsLayout = true
+            statusItem.button?.layoutSubtreeIfNeeded()
         }
 
         let newMessageCount = Int(newText) ?? 0


### PR DESCRIPTION
Fixes #69. 

Screenshot before the fix:

<img width="568" height="404" alt="image" src="https://github.com/user-attachments/assets/aff8a49e-6fe6-4d51-bec7-b57502d5105e" />


Screenshot after the fix:

<img width="778" height="104" alt="image" src="https://github.com/user-attachments/assets/2a2f0ce4-4e71-4758-acbb-4663d55b0d07" />
